### PR TITLE
feat: add component provider field for codegen

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,12 @@
     "android": {
       "javaPackageName": "com.th3rdwave.safeareacontext"
     },
+    "ios": {
+      "componentProvider": {
+        "RNCSafeAreaProvider": "RNCSafeAreaProviderComponentView",
+        "RNCSafeAreaView": "RNCSafeAreaViewComponentView"
+      }
+    },
     "name": "safeareacontext",
     "type": "all",
     "jsSrcsDir": "./src/specs"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

```[Codegen] [DEPRECATED] react-native-safe-area-context should add the 'ios.componentProvider' property in their codegenConfig```

See: https://x.com/o_kwasniewski/status/1876960622832697391

![CleanShot 2025-01-21 at 17 31 27@2x](https://github.com/user-attachments/assets/35088200-635c-4ea7-bdf9-ad784d3dcac6)


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

RNTA works as expected - haven't noticed any regressions
