### PR TITLE
feat: Add react-native 0.78 support

### DIFF
--- a/common/cpp/react/renderer/components/safeareacontext/RNCSafeAreaViewShadowNode.cpp
+++ b/common/cpp/react/renderer/components/safeareacontext/RNCSafeAreaViewShadowNode.cpp
@@ -16,10 +16,10 @@ inline Style::Length valueFromEdges(
     Style::Length edge,
     Style::Length axis,
     Style::Length defaultValue) {
-  if (edge.unit() != Unit::Undefined) {
+  if (!edge.isUndefined()) {
     return edge;
   }
-  if (axis.unit() != Unit::Undefined) {
+  if (!axis.isUndefined()) {
     return axis;
   }
   return defaultValue;


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
In react-native 0.78, they removed `StyleLength::unit()`. Instead, you can check `StyleLength::isUndefined()` directly, which achieves the same thing.

Technically not backwards compatible, but I remember Janic saying the policy for new arch is to not be backwards compatible until it is stable and used by (pretty much) everyone.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


## Test Plan
Build an app with RN 78. Currently in RC.1
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
