### PR TITLE
chore: suppress `-Wdollar-in-identifier-extension` compiler warning

### DIFF
--- a/android/src/main/jni/CMakeLists.txt
+++ b/android/src/main/jni/CMakeLists.txt
@@ -16,6 +16,7 @@ add_compile_options(
   -Wall
   -Wpedantic
   -Wno-gnu-zero-variadic-macro-arguments
+  -Wno-dollar-in-identifier-extension
 )
 
 file(GLOB LIB_CUSTOM_SRCS CONFIGURE_DEPENDS *.cpp ${LIB_COMMON_DIR}/react/renderer/components/${LIB_LITERAL}/*.cpp)


### PR DESCRIPTION
## Summary

Following https://github.com/software-mansion/react-native-screens/pull/2707

Variable names prefixed with `$` are heavily utilised in codegened code. This leads to a wall of warnings popping up during every Android build. This PR aims to suppress these warnings.

![image](https://github.com/user-attachments/assets/8530d40d-bfb3-4a07-80a2-b086214737c9)

☝🏻 and that is not all...

## Test Plan

Just build Fabric + Android with this change. 
