### PR TITLE
Fix issues with inset calculation for apps targeting Android SDK 35+

### DIFF
--- a/android/src/main/java/com/th3rdwave/safeareacontext/EdgeInsets.kt
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/EdgeInsets.kt
@@ -1,3 +1,7 @@
 package com.th3rdwave.safeareacontext
 
-data class EdgeInsets(val top: Float, val right: Float, val bottom: Float, val left: Float)
+data class EdgeInsets(val top: Float, val right: Float, val bottom: Float, val left: Float) {
+    override fun toString(): String {
+        return "(top=${top}, right=${right}, bottom=${bottom}, left=${left})"
+    }
+}

--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaProvider.kt
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaProvider.kt
@@ -1,47 +1,63 @@
 package com.th3rdwave.safeareacontext
 
 import android.content.Context
+import android.util.Log
 import android.view.ViewGroup
-import android.view.ViewTreeObserver
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import com.facebook.react.views.view.ReactViewGroup
+
+const val DEBUG = false 
 
 typealias OnInsetsChangeHandler = (view: SafeAreaProvider, insets: EdgeInsets, frame: Rect) -> Unit
 
-class SafeAreaProvider(context: Context?) :
-    ReactViewGroup(context), ViewTreeObserver.OnPreDrawListener {
+class SafeAreaProvider(context: Context?) : ReactViewGroup(context) {
   private var mInsetsChangeHandler: OnInsetsChangeHandler? = null
-  private var mLastInsets: EdgeInsets? = null
-  private var mLastFrame: Rect? = null
+  private var mCurrentInsets: EdgeInsets = EdgeInsets(0.0f, 0.0f, 0.0f, 0.0f)
 
-  private fun maybeUpdateInsets() {
-    val insetsChangeHandler = mInsetsChangeHandler ?: return
-    val edgeInsets = getSafeAreaInsets(this) ?: return
-    val frame = getFrame(rootView as ViewGroup, this) ?: return
-    if (mLastInsets != edgeInsets || mLastFrame != frame) {
-      insetsChangeHandler(this, edgeInsets, frame)
-      mLastInsets = edgeInsets
-      mLastFrame = frame
+  init {
+    ViewCompat.setOnApplyWindowInsetsListener(this) { _, insets ->
+      val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+
+      mCurrentInsets = EdgeInsets(
+        systemBars.top.toFloat(),
+        systemBars.left.toFloat(),
+        systemBars.bottom.toFloat(),
+        systemBars.right.toFloat())
+
+      if (DEBUG) {
+        Log.d("SafeAreaProvider", "calculated insets: $mCurrentInsets")
+      }
+
+      sendInsetValuesToJs()
+
+      insets
     }
   }
 
-  override fun onAttachedToWindow() {
-    super.onAttachedToWindow()
-    viewTreeObserver.addOnPreDrawListener(this)
-    maybeUpdateInsets()
-  }
+  private fun sendInsetValuesToJs() {
+    val insetsChangeHandler = mInsetsChangeHandler ?: return
+    val frame = getFrame(rootView as ViewGroup, this) ?: return
 
-  override fun onDetachedFromWindow() {
-    super.onDetachedFromWindow()
-    viewTreeObserver.removeOnPreDrawListener(this)
-  }
+    if (DEBUG) {
+      Log.d("SafeAreaProvider",  "emitting updated insets: $mCurrentInsets")
+    }
 
-  override fun onPreDraw(): Boolean {
-    maybeUpdateInsets()
-    return true
+    insetsChangeHandler(this, mCurrentInsets, frame)
   }
 
   fun setOnInsetsChangeHandler(handler: OnInsetsChangeHandler?) {
     mInsetsChangeHandler = handler
-    maybeUpdateInsets()
+    sendInsetValuesToJs()
+  }
+
+  override fun onAttachedToWindow() {
+    super.onAttachedToWindow()
+
+    if (DEBUG) {
+      Log.d("SafeAreaProvider", "attached to window")
+    }
+
+    requestApplyInsets()
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

We recently ran into an issue with `react-native-safe-area-context` returning `0` for top and bottom insets after upgrading our project to Android SDK 35. Turns out others have experienced this issue as well:
* https://github.com/AppAndFlow/react-native-safe-area-context/issues/552
* https://github.com/AppAndFlow/react-native-safe-area-context/issues/546

We addressed this issue by changing the strategy used to resolve the insets; instead of using `ViewTreeObserver.OnPreDrawListener` to detect changes, this commit migrates to using `ViewCompat.setOnApplyWindowInsets`, which seems to be the preferred way to calculate insets anyway.

**Note**: this is against the 4.x branch, as we are not able to use 5.x yet, although the changes should still be applicable. 

## Test Plan

N/A
