### PR TITLE
feat: add new arch support to macos

### DIFF
--- a/ios/Fabric/RNCSafeAreaProviderComponentView.h
+++ b/ios/Fabric/RNCSafeAreaProviderComponentView.h
@@ -1,4 +1,8 @@
+#if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
+#elif TARGET_OS_OSX
+#import <AppKit/AppKit.h>
+#endif
 
 #import <React/RCTViewComponentView.h>
 

--- a/ios/Fabric/RNCSafeAreaProviderComponentView.mm
+++ b/ios/Fabric/RNCSafeAreaProviderComponentView.mm
@@ -31,7 +31,7 @@ using namespace facebook::react;
     static const auto defaultProps = std::make_shared<const RNCSafeAreaProviderProps>();
     _props = defaultProps;
 
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_OSX
     [NSNotificationCenter.defaultCenter addObserver:self
                                            selector:@selector(invalidateSafeAreaInsets)
                                                name:UIKeyboardDidShowNotification
@@ -67,7 +67,11 @@ using namespace facebook::react;
   CGRect frame = [self convertRect:self.bounds toView:RNCParentViewController(self).view];
 
   if (_initialInsetsSent &&
+#if TARGET_OS_IPHONE
       UIEdgeInsetsEqualToEdgeInsetsWithThreshold(safeAreaInsets, _currentSafeAreaInsets, 1.0 / RCTScreenScale()) &&
+#elif TARGET_OS_OSX
+      NSEdgeInsetsEqualToEdgeInsetsWithThreshold(safeAreaInsets, _currentSafeAreaInsets, 1.0 / RCTScreenScale()) &&
+#endif
       CGRectEqualToRect(frame, _currentFrame)) {
     return;
   }

--- a/ios/Fabric/RNCSafeAreaViewComponentView.h
+++ b/ios/Fabric/RNCSafeAreaViewComponentView.h
@@ -1,4 +1,8 @@
+#if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
+#elif TARGET_OS_OSX
+#import <AppKit/AppKit.h>
+#endif
 
 #import <React/RCTViewComponentView.h>
 

--- a/ios/Fabric/RNCSafeAreaViewComponentView.mm
+++ b/ios/Fabric/RNCSafeAreaViewComponentView.mm
@@ -58,10 +58,10 @@ using namespace facebook::react;
                                                                           _providerView.safeAreaInsets.bottom,
                                                                           _providerView.safeAreaInsets.right];
   NSString *currentSafeAreaInsetsString = [NSString stringWithFormat:@"{%f,%f,%f,%f}",
-                                                                    _currentSafeAreaInsets.top,
-                                                                    _currentSafeAreaInsets.left,
-                                                                    _currentSafeAreaInsets.bottom,
-                                                                    _currentSafeAreaInsets.right];
+                                                                     _currentSafeAreaInsets.top,
+                                                                     _currentSafeAreaInsets.left,
+                                                                     _currentSafeAreaInsets.bottom,
+                                                                     _currentSafeAreaInsets.right];
 #endif
 
   return [NSString stringWithFormat:@"%@; RNCSafeAreaInsets = %@; appliedRNCSafeAreaInsets = %@>",

--- a/ios/Fabric/RNCSafeAreaViewComponentView.mm
+++ b/ios/Fabric/RNCSafeAreaViewComponentView.mm
@@ -47,28 +47,21 @@ using namespace facebook::react;
   if (superDescription.length > 0 && [superDescription characterAtIndex:superDescription.length - 1] == '>') {
     superDescription = [superDescription substringToIndex:superDescription.length - 1];
   }
-  
+
 #if TARGET_OS_IPHONE
   NSString *providerViewSafeAreaInsetsString = NSStringFromUIEdgeInsets(_providerView.safeAreaInsets);
   NSString *currentSafeAreaInsetsString = NSStringFromUIEdgeInsets(_currentSafeAreaInsets);
 #elif TARGET_OS_OSX
-  NSString *providerViewSafeAreaInsetsString;
-  NSString *currentSafeAreaInsetsString;
-  if (@available(macOS 11.0, *)) {
-    providerViewSafeAreaInsetsString = [NSString stringWithFormat:@"{%f,%f,%f,%f}",
-                                        _providerView.safeAreaInsets.top,
-                                        _providerView.safeAreaInsets.left,
-                                        _providerView.safeAreaInsets.bottom,
-                                        _providerView.safeAreaInsets.right];
-    currentSafeAreaInsetsString = [NSString stringWithFormat:@"{%f,%f,%f,%f}",
-                                   _currentSafeAreaInsets.top,
-                                   _currentSafeAreaInsets.left,
-                                   _currentSafeAreaInsets.bottom,
-                                   _currentSafeAreaInsets.right];
-  } else {
-    providerViewSafeAreaInsetsString = @"{0.0,0.0,0.0,0.0}";
-    currentSafeAreaInsetsString = @"{0.0,0.0,0.0,0.0}";
-  }
+  NSString *providerViewSafeAreaInsetsString = [NSString stringWithFormat:@"{%f,%f,%f,%f}",
+                                                                          _providerView.safeAreaInsets.top,
+                                                                          _providerView.safeAreaInsets.left,
+                                                                          _providerView.safeAreaInsets.bottom,
+                                                                          _providerView.safeAreaInsets.right];
+  NSString *currentSafeAreaInsetsString = [NSString stringWithFormat:@"{%f,%f,%f,%f}",
+                                                                    _currentSafeAreaInsets.top,
+                                                                    _currentSafeAreaInsets.left,
+                                                                    _currentSafeAreaInsets.bottom,
+                                                                    _currentSafeAreaInsets.right];
 #endif
 
   return [NSString stringWithFormat:@"%@; RNCSafeAreaInsets = %@; appliedRNCSafeAreaInsets = %@>",

--- a/ios/Fabric/RNCSafeAreaViewComponentView.mm
+++ b/ios/Fabric/RNCSafeAreaViewComponentView.mm
@@ -47,11 +47,34 @@ using namespace facebook::react;
   if (superDescription.length > 0 && [superDescription characterAtIndex:superDescription.length - 1] == '>') {
     superDescription = [superDescription substringToIndex:superDescription.length - 1];
   }
+  
+#if TARGET_OS_IPHONE
+  NSString *providerViewSafeAreaInsetsString = NSStringFromUIEdgeInsets(_providerView.safeAreaInsets);
+  NSString *currentSafeAreaInsetsString = NSStringFromUIEdgeInsets(_currentSafeAreaInsets);
+#elif TARGET_OS_OSX
+  NSString *providerViewSafeAreaInsetsString;
+  NSString *currentSafeAreaInsetsString;
+  if (@available(macOS 11.0, *)) {
+    providerViewSafeAreaInsetsString = [NSString stringWithFormat:@"{%f,%f,%f,%f}",
+                                        _providerView.safeAreaInsets.top,
+                                        _providerView.safeAreaInsets.left,
+                                        _providerView.safeAreaInsets.bottom,
+                                        _providerView.safeAreaInsets.right];
+    currentSafeAreaInsetsString = [NSString stringWithFormat:@"{%f,%f,%f,%f}",
+                                   _currentSafeAreaInsets.top,
+                                   _currentSafeAreaInsets.left,
+                                   _currentSafeAreaInsets.bottom,
+                                   _currentSafeAreaInsets.right];
+  } else {
+    providerViewSafeAreaInsetsString = @"{0.0,0.0,0.0,0.0}";
+    currentSafeAreaInsetsString = @"{0.0,0.0,0.0,0.0}";
+  }
+#endif
 
   return [NSString stringWithFormat:@"%@; RNCSafeAreaInsets = %@; appliedRNCSafeAreaInsets = %@>",
                                     superDescription,
-                                    NSStringFromUIEdgeInsets(_providerView.safeAreaInsets),
-                                    NSStringFromUIEdgeInsets(_currentSafeAreaInsets)];
+                                    providerViewSafeAreaInsetsString,
+                                    currentSafeAreaInsetsString];
 }
 
 - (void)didMoveToWindow
@@ -80,12 +103,18 @@ using namespace facebook::react;
   if (_providerView == nil) {
     return;
   }
+#if TARGET_OS_IPHONE
   UIEdgeInsets safeAreaInsets = _providerView.safeAreaInsets;
 
   if (UIEdgeInsetsEqualToEdgeInsetsWithThreshold(safeAreaInsets, _currentSafeAreaInsets, 1.0 / RCTScreenScale())) {
     return;
   }
-
+#elif TARGET_OS_OSX
+  NSEdgeInsets safeAreaInsets = _providerView.safeAreaInsets;
+  if (NSEdgeInsetsEqualToEdgeInsetsWithThreshold(safeAreaInsets, _currentSafeAreaInsets, 1.0 / RCTScreenScale())) {
+    return;
+  }
+#endif
   _currentSafeAreaInsets = safeAreaInsets;
   [self updateState];
 }

--- a/ios/RNCSafeAreaUtils.h
+++ b/ios/RNCSafeAreaUtils.h
@@ -4,6 +4,7 @@
 #import <UIKit/UIKit.h>
 #elif TARGET_OS_OSX
 #import <AppKit/AppKit.h>
+typedef NSView UIView;
 #endif
 
 extern NSString *const RNCSafeAreaDidChange;


### PR DESCRIPTION
## Summary

Follow up of https://github.com/AppAndFlow/react-native-safe-area-context/pull/513

While building BareExpo for macOS I noticed that macOS builds are broken when using the new arch. This PR added the necessary platform checks to fix it 

## Test Plan

Manually added macOS to the sample app so I could test it manually.  


