### PR TITLE
chore(android): support react-native 0.79.0

### DIFF
--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaViewManager.kt
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaViewManager.kt
@@ -5,19 +5,19 @@ import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.ReactStylesDiffMap
 import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.ViewManagerDelegate
 import com.facebook.react.uimanager.annotations.ReactProp
+import com.facebook.react.viewmanagers.RNCSafeAreaViewManagerDelegate
 import com.facebook.react.viewmanagers.RNCSafeAreaViewManagerInterface
-import com.facebook.react.views.view.ReactViewGroup
-import com.facebook.react.views.view.ReactViewManager
 
 @ReactModule(name = SafeAreaViewManager.REACT_CLASS)
-class SafeAreaViewManager : ReactViewManager(), RNCSafeAreaViewManagerInterface<SafeAreaView> {
+class SafeAreaViewManager : ViewGroupManager<SafeAreaView>(), RNCSafeAreaViewManagerInterface<SafeAreaView> {
   override fun getName() = REACT_CLASS
 
-  // Make sure we're not using delegates for now since ReactViewGroupManager doesn't use one. If it
-  // does in the future we will need a way to compose delegates together.
-  override fun getDelegate(): ViewManagerDelegate<ReactViewGroup>? = null
+    private val delegate: ViewManagerDelegate<SafeAreaView> = RNCSafeAreaViewManagerDelegate(this)
+
+  override fun getDelegate(): ViewManagerDelegate<SafeAreaView> = delegate
 
   override fun createViewInstance(context: ThemedReactContext) = SafeAreaView(context)
 
@@ -59,11 +59,11 @@ class SafeAreaViewManager : ReactViewManager(), RNCSafeAreaViewManagerInterface<
   }
 
   override fun updateState(
-      view: ReactViewGroup,
+      view: SafeAreaView,
       props: ReactStylesDiffMap?,
       stateWrapper: StateWrapper?
   ): Any? {
-    (view as SafeAreaView).setStateWrapper(stateWrapper)
+    view.setStateWrapper(stateWrapper)
     return null
   }
 

--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaViewManager.kt
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaViewManager.kt
@@ -12,10 +12,11 @@ import com.facebook.react.viewmanagers.RNCSafeAreaViewManagerDelegate
 import com.facebook.react.viewmanagers.RNCSafeAreaViewManagerInterface
 
 @ReactModule(name = SafeAreaViewManager.REACT_CLASS)
-class SafeAreaViewManager : ViewGroupManager<SafeAreaView>(), RNCSafeAreaViewManagerInterface<SafeAreaView> {
+class SafeAreaViewManager :
+    ViewGroupManager<SafeAreaView>(), RNCSafeAreaViewManagerInterface<SafeAreaView> {
   override fun getName() = REACT_CLASS
 
-    private val delegate: ViewManagerDelegate<SafeAreaView> = RNCSafeAreaViewManagerDelegate(this)
+  private val delegate: ViewManagerDelegate<SafeAreaView> = RNCSafeAreaViewManagerDelegate(this)
 
   override fun getDelegate(): ViewManagerDelegate<SafeAreaView> = delegate
 

--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaViewManager.kt
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaViewManager.kt
@@ -5,20 +5,13 @@ import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.ReactStylesDiffMap
 import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.uimanager.ThemedReactContext
-import com.facebook.react.uimanager.ViewGroupManager
-import com.facebook.react.uimanager.ViewManagerDelegate
 import com.facebook.react.uimanager.annotations.ReactProp
-import com.facebook.react.viewmanagers.RNCSafeAreaViewManagerDelegate
-import com.facebook.react.viewmanagers.RNCSafeAreaViewManagerInterface
+import com.facebook.react.views.view.ReactViewGroup
+import com.facebook.react.views.view.ReactViewManager
 
 @ReactModule(name = SafeAreaViewManager.REACT_CLASS)
-class SafeAreaViewManager :
-    ViewGroupManager<SafeAreaView>(), RNCSafeAreaViewManagerInterface<SafeAreaView> {
+class SafeAreaViewManager : ReactViewManager() {
   override fun getName() = REACT_CLASS
-
-  private val delegate: ViewManagerDelegate<SafeAreaView> = RNCSafeAreaViewManagerDelegate(this)
-
-  override fun getDelegate(): ViewManagerDelegate<SafeAreaView> = delegate
 
   override fun createViewInstance(context: ThemedReactContext) = SafeAreaView(context)
 
@@ -27,7 +20,7 @@ class SafeAreaViewManager :
   override fun getShadowNodeClass() = SafeAreaViewShadowNode::class.java
 
   @ReactProp(name = "mode")
-  override fun setMode(view: SafeAreaView, mode: String?) {
+  fun setMode(view: SafeAreaView, mode: String?) {
     when (mode) {
       "padding" -> {
         view.setMode(SafeAreaViewMode.PADDING)
@@ -39,7 +32,7 @@ class SafeAreaViewManager :
   }
 
   @ReactProp(name = "edges")
-  override fun setEdges(view: SafeAreaView, propList: ReadableMap?) {
+  fun setEdges(view: SafeAreaView, propList: ReadableMap?) {
     if (propList != null) {
       view.setEdges(
           SafeAreaViewEdges(
@@ -60,11 +53,11 @@ class SafeAreaViewManager :
   }
 
   override fun updateState(
-      view: SafeAreaView,
+      view: ReactViewGroup,
       props: ReactStylesDiffMap?,
       stateWrapper: StateWrapper?
   ): Any? {
-    view.setStateWrapper(stateWrapper)
+    (view as SafeAreaView).setStateWrapper(stateWrapper)
     return null
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Release of React Native 0.79 broke Android builds that resulted in an error:

```sh
Exception thrown when executing UIFrameGuarded

Attempt to invoke interface method 'void com.facebook.react.uimanager.ViewManagerDelegate.setProperty(android.view.View, java.lang.String, java.lang.Object)' on a null object reference
```
Tested on React Native 0.76.1 example and React Native 0.79.0

Closes https://github.com/AppAndFlow/react-native-safe-area-context/issues/607

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


## Test Plan

- Build example project
- Build on project using React Native 0.79

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
