### PR TITLE
Add IME Padding on Android

### DIFF
--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaUtils.kt
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaUtils.kt
@@ -16,7 +16,8 @@ private fun getRootWindowInsetsCompatR(rootView: View): EdgeInsets? {
           WindowInsets.Type.statusBars() or
               WindowInsets.Type.displayCutout() or
               WindowInsets.Type.navigationBars() or
-              WindowInsets.Type.captionBar())
+              WindowInsets.Type.captionBar() or
+              WindowInsets.Type.ime())
           ?: return null
   return EdgeInsets(
       top = insets.top.toFloat(),


### PR DESCRIPTION
## Summary
- IME padding should be added when edge-to-edge is enabled as noted [here](https://stackoverflow.com/questions/79177674/windowsoftinputmode-adjustresize-doesnt-work-in-target-sdk-35/79364446#79364446)
- The keyboard avoidance will not work if the 'android:windowSoftInputMode' is set to 'adjustResize' and there is no IME padding.

## Test Plan

- Build app from Android 35 and below
