### PR TITLE
Prevent invalidateSafeAreaInsets get call when RNCSafeAreaProviderComponentView still in the fabric view pool

### DIFF
--- a/ios/Fabric/RNCSafeAreaProviderComponentView.mm
+++ b/ios/Fabric/RNCSafeAreaProviderComponentView.mm
@@ -57,6 +57,7 @@ using namespace facebook::react;
 
 - (void)invalidateSafeAreaInsets
 {
+  if (self.superview == nil) { return; }
   // This gets called before the view size is set by react-native so
   // make sure to wait so we don't set wrong insets to JS.
   if (CGSizeEqualToSize(self.frame.size, CGSizeZero)) {
@@ -123,6 +124,7 @@ using namespace facebook::react;
   _currentSafeAreaInsets = UIEdgeInsetsZero;
   _currentFrame = CGRectZero;
   _initialInsetsSent = NO;
+  [NSNotificationCenter.defaultCenter removeObserver:self];
 }
 
 @end

--- a/ios/Fabric/RNCSafeAreaProviderComponentView.mm
+++ b/ios/Fabric/RNCSafeAreaProviderComponentView.mm
@@ -17,6 +17,7 @@ using namespace facebook::react;
   UIEdgeInsets _currentSafeAreaInsets;
   CGRect _currentFrame;
   BOOL _initialInsetsSent;
+  BOOL _registeredNotifications;
 }
 
 // Needed because of this: https://github.com/facebook/react-native/pull/37274
@@ -30,7 +31,21 @@ using namespace facebook::react;
   if (self = [super initWithFrame:frame]) {
     static const auto defaultProps = std::make_shared<const RNCSafeAreaProviderProps>();
     _props = defaultProps;
+  }
 
+  return self;
+}
+
+- (void)willMoveToSuperview:(UIView*)newSuperView {
+    [super willMoveToSuperview:newSuperView];
+
+    if (newSuperView != nil && !_registeredNotifications) {
+        _registeredNotifications = YES;
+        [self registerNotifications];
+    }
+}
+
+- (void)registerNotifications {
 #if !TARGET_OS_TV && !TARGET_OS_OSX
     [NSNotificationCenter.defaultCenter addObserver:self
                                            selector:@selector(invalidateSafeAreaInsets)
@@ -45,9 +60,6 @@ using namespace facebook::react;
                                                name:UIKeyboardDidChangeFrameNotification
                                              object:nil];
 #endif
-  }
-
-  return self;
 }
 
 - (void)safeAreaInsetsDidChange
@@ -125,6 +137,7 @@ using namespace facebook::react;
   _currentFrame = CGRectZero;
   _initialInsetsSent = NO;
   [NSNotificationCenter.defaultCenter removeObserver:self];
+  _registeredNotifications = NO;
 }
 
 @end

--- a/ios/Fabric/RNCSafeAreaProviderComponentView.mm
+++ b/ios/Fabric/RNCSafeAreaProviderComponentView.mm
@@ -36,29 +36,31 @@ using namespace facebook::react;
   return self;
 }
 
-- (void)willMoveToSuperview:(UIView*)newSuperView {
-    [super willMoveToSuperview:newSuperView];
+- (void)willMoveToSuperview:(UIView *)newSuperView
+{
+  [super willMoveToSuperview:newSuperView];
 
-    if (newSuperView != nil && !_registeredNotifications) {
-        _registeredNotifications = YES;
-        [self registerNotifications];
-    }
+  if (newSuperView != nil && !_registeredNotifications) {
+    _registeredNotifications = YES;
+    [self registerNotifications];
+  }
 }
 
-- (void)registerNotifications {
+- (void)registerNotifications
+{
 #if !TARGET_OS_TV && !TARGET_OS_OSX
-    [NSNotificationCenter.defaultCenter addObserver:self
-                                           selector:@selector(invalidateSafeAreaInsets)
-                                               name:UIKeyboardDidShowNotification
-                                             object:nil];
-    [NSNotificationCenter.defaultCenter addObserver:self
-                                           selector:@selector(invalidateSafeAreaInsets)
-                                               name:UIKeyboardDidHideNotification
-                                             object:nil];
-    [NSNotificationCenter.defaultCenter addObserver:self
-                                           selector:@selector(invalidateSafeAreaInsets)
-                                               name:UIKeyboardDidChangeFrameNotification
-                                             object:nil];
+  [NSNotificationCenter.defaultCenter addObserver:self
+                                         selector:@selector(invalidateSafeAreaInsets)
+                                             name:UIKeyboardDidShowNotification
+                                           object:nil];
+  [NSNotificationCenter.defaultCenter addObserver:self
+                                         selector:@selector(invalidateSafeAreaInsets)
+                                             name:UIKeyboardDidHideNotification
+                                           object:nil];
+  [NSNotificationCenter.defaultCenter addObserver:self
+                                         selector:@selector(invalidateSafeAreaInsets)
+                                             name:UIKeyboardDidChangeFrameNotification
+                                           object:nil];
 #endif
 }
 
@@ -69,7 +71,9 @@ using namespace facebook::react;
 
 - (void)invalidateSafeAreaInsets
 {
-  if (self.superview == nil) { return; }
+  if (self.superview == nil) {
+    return;
+  }
   // This gets called before the view size is set by react-native so
   // make sure to wait so we don't set wrong insets to JS.
   if (CGSizeEqualToSize(self.frame.size, CGSizeZero)) {


### PR DESCRIPTION
…

Currently, RNCSafeAreaProviderComponentView is a fabric view. Fabric view using a reusable for views.
We already had `prepareForRecycle` to clean up the state of view when it was removed from the superview.
But we still have 2 things that can affect the state. 
The first one is the notification center. We have not removed it. Then `invalidateSafeAreaInsets` still get called when other places show the keyboard. It will lead to `_initialInsetsSent` being true, and our lib will not emit an event to js. (We have a return)

The second, UIKit still calls `invalidateSafeAreaInsets` when the keyboard shows. So we need a guard to prevent it affect our logic.

## Summary

We have a problem SafeAreaProvider empty children since `insets` is null, caused by other brownfield screen shows keyboard
