### PR TITLE
fix building Fabric on macOS

### DIFF
--- a/ios/Fabric/RNCSafeAreaProviderComponentView.mm
+++ b/ios/Fabric/RNCSafeAreaProviderComponentView.mm
@@ -36,6 +36,7 @@ using namespace facebook::react;
   return self;
 }
 
+#if !TARGET_OS_OSX
 - (void)willMoveToSuperview:(UIView *)newSuperView
 {
   [super willMoveToSuperview:newSuperView];
@@ -45,6 +46,7 @@ using namespace facebook::react;
     [self registerNotifications];
   }
 }
+#endif
 
 - (void)registerNotifications
 {


### PR DESCRIPTION
## Summary

While refactoring `RNCSafeAreaProviderComponentView` in https://github.com/AppAndFlow/react-native-safe-area-context/pull/629 we ended up breaking builds for macOS because the `willMoveToSuperview` method does not exist in NSView's. 
Given that this function is just being used for registering notifications, which are not used in macOS, we can just add a platform check to the whole block without needing to use the equivalent `viewWillMoveToSuperview` function

## Test Plan

Before 

<img width="718" alt="image" src="https://github.com/user-attachments/assets/ab22140a-090e-4646-b49b-4a02fcb3f573" />

After 

<img width="540" alt="image" src="https://github.com/user-attachments/assets/6b2cde56-d9f9-4517-8a6b-1d58477aef97" />

![image](https://github.com/user-attachments/assets/605439dd-0f10-4feb-9795-5841911d71cb)

