### PR TITLE
[RN 0.81] Do not set the `ShadowNodeTraits::Trait::DirtyYogaNode`

### DIFF
--- a/common/cpp/react/renderer/components/safeareacontext/RNCSafeAreaViewShadowNode.h
+++ b/common/cpp/react/renderer/components/safeareacontext/RNCSafeAreaViewShadowNode.h
@@ -24,9 +24,7 @@ class JSI_EXPORT RNCSafeAreaViewShadowNode final
 
  public:
   static ShadowNodeTraits BaseTraits() {
-    auto traits = ConcreteViewShadowNode::BaseTraits();
-    traits.set(ShadowNodeTraits::Trait::DirtyYogaNode);
-    return traits;
+    return ConcreteViewShadowNode::BaseTraits();
   }
 
   void adjustLayoutWithState();

--- a/common/cpp/react/renderer/components/safeareacontext/RNCSafeAreaViewShadowNode.h
+++ b/common/cpp/react/renderer/components/safeareacontext/RNCSafeAreaViewShadowNode.h
@@ -23,10 +23,6 @@ class JSI_EXPORT RNCSafeAreaViewShadowNode final
   using ConcreteViewShadowNode::ConcreteViewShadowNode;
 
  public:
-  static ShadowNodeTraits BaseTraits() {
-    return ConcreteViewShadowNode::BaseTraits();
-  }
-
   void adjustLayoutWithState();
 };
 


### PR DESCRIPTION
## Summary

Not sure why you folks are setting the `ShadowNodeTraits::Trait::DirtyYogaNode` trait on the SafeAreaView Shadow Node (is it a copy form the core one?).

This trait is going away in core in 0.81.
I'm actually re-adding it to reduce the blast radius of this breaking change, but still it would be worth to clean this up.

Fixes https://github.com/AppAndFlow/react-native-safe-area-context/issues/645