### PR TITLE
feat: Set compile options using target_compile_reactnative_options

### DIFF
--- a/android/src/main/jni/CMakeLists.txt
+++ b/android/src/main/jni/CMakeLists.txt
@@ -9,16 +9,6 @@ set(LIB_COMMON_DIR ${LIB_ANDROID_DIR}/../common/cpp)
 set(LIB_ANDROID_GENERATED_JNI_DIR ${LIB_ANDROID_DIR}/build/generated/source/codegen/jni)
 set(LIB_ANDROID_GENERATED_COMPONENTS_DIR ${LIB_ANDROID_GENERATED_JNI_DIR}/react/renderer/components/${LIB_LITERAL})
 
-add_compile_options(
-  -fexceptions
-  -frtti
-  -std=c++20
-  -Wall
-  -Wpedantic
-  -Wno-gnu-zero-variadic-macro-arguments
-  -Wno-dollar-in-identifier-extension
-)
-
 file(GLOB LIB_CUSTOM_SRCS CONFIGURE_DEPENDS *.cpp ${LIB_COMMON_DIR}/react/renderer/components/${LIB_LITERAL}/*.cpp)
 file(GLOB LIB_CODEGEN_SRCS CONFIGURE_DEPENDS ${LIB_ANDROID_GENERATED_JNI_DIR}/*.cpp ${LIB_ANDROID_GENERATED_COMPONENTS_DIR}/*.cpp)
 
@@ -69,19 +59,29 @@ else()
   )
 endif()
 
-
-target_compile_options(
-  ${LIB_TARGET_NAME}
-  PRIVATE
-  -DLOG_TAG=\"ReactNative\"
-  -fexceptions
-  -frtti
-  -std=c++20
-  -Wall
-)
-
 target_include_directories(
   ${CMAKE_PROJECT_NAME}
   PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 80)
+  target_compile_reactnative_options(${LIB_TARGET_NAME} PUBLIC)
+else()
+  target_compile_options(
+    ${LIB_TARGET_NAME}
+    PRIVATE
+    -fexceptions
+    -frtti
+    -std=c++20
+    -Wall
+  )
+endif()
+
+target_compile_options(
+  ${LIB_TARGET_NAME}
+  PRIVATE
+  -Wpedantic
+  -Wno-gnu-zero-variadic-macro-arguments
+  -Wno-dollar-in-identifier-extension
 )


### PR DESCRIPTION
## Summary

PR based on https://github.com/software-mansion/react-native-reanimated/pull/7776 by @tomekzaw.

To support `react-native@0.81.0`, we need to include `RN_SERIALIZABLE_STATE`. This can be done using `target_compile_reactnative_options`, which sets the necessary flags and definitions automatically, instead of setting them manually.

## Test Plan

- tested inside of expo/expo repo with RN 0.81 enable ✅ 
