### PR TITLE
fix: Move jest/mock into package build (fix TS under RN 0.87)

### DIFF
--- a/jest/mock.d.ts
+++ b/jest/mock.d.ts
@@ -1,0 +1,1 @@
+export { default } from '../lib/typescript/src/jest/mock';

--- a/jest/mock.js
+++ b/jest/mock.js
@@ -1,0 +1,1 @@
+module.exports = require('../lib/commonjs/jest/mock');

--- a/src/jest/mock.tsx
+++ b/src/jest/mock.tsx
@@ -1,11 +1,11 @@
 import { jest } from '@jest/globals';
 import React, { useContext } from 'react';
-import type { Metrics } from '../src/SafeArea.types';
+import type { Metrics } from '../SafeArea.types';
 import type {
   SafeAreaProviderProps,
   SafeAreaInsetsContext,
   SafeAreaFrameContext,
-} from '../src/SafeAreaContext';
+} from '../SafeAreaContext';
 
 const MOCK_INITIAL_METRICS: Metrics = {
   frame: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "rootDir": ".",
     "allowJs": false,
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
@@ -23,8 +24,7 @@
   "include": [
     "src",
     ".eslintrc.js",
-    "babel.config.js",
-    "jest"
+    "babel.config.js"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary

Minimal fix for `react-native-safe-area-context` compatibility in  React Native 0.87 projects. See https://github.com/react-native-community/template/issues/245.

**Context**

The incoming React Native 0.87 release will ship the [Strict TypeScript API](https://reactnative.dev/docs/next/strict-typescript-api) by default (moving to a user opt-out).

Typically, this change is **scoped to the user's project** (`@react-native/typescript-config` includes [`skipLibCheck: true`](https://www.typescriptlang.org/tsconfig/#skipLibCheck)) and not library source code.

However, `react-native-safe-area-context` ships a Jest integration, which is an exception that crosses this boundary:

```js
setupFiles: ['react-native-safe-area-context/jest/mock']
```

**Problem**: `react-native-safe-area-context/jest/mock` pulls `../src/*` (of this library) into the scope of the user's TypeScript analysis — instead of the compiled `lib/` code, producing a type error against deep imports such as `react-native/Libraries/Types/CodegenTypes` which no longer resolve (see also https://github.com/AppAndFlow/react-native-safe-area-context/pull/744).

**This diff**

Fix this types breakage for app consumers, independent of https://github.com/AppAndFlow/react-native-safe-area-context/pull/744.

- Move `jest/mock.tsx` to `src/jest/mock.tsx` so builder-bob compiles it like the rest of the library. The `react-native-safe-area-context/jest/mock` subpath is preserved via shims.
- ✅ Consuming projects now only see this library's `.d.ts` files, which are exempt from typechecking due to`skipLibCheck: false`.

## Test Plan

- `yarn validate:typescript`, ESlint, and the Jest suite all pass.
- Simulated an RN 0.88 (main) consumer app with TypeScript 6: published 5.8.0 reproduces the 6 errors from the issue; the packed build from this change typechecks clean.
- Runtime smoke test: The shim loads the compiled mock under Jest, and `SafeAreaProvider`/`useSafeAreaInsets`/`useSafeAreaFrame` render the mock metrics through context.