### PR TITLE
fix: iOS 26.4+ can leave reattached views' safeAreaInsets stale (zero-inset latch)

### DIFF
--- a/ios/Fabric/RNCSafeAreaProviderComponentView.mm
+++ b/ios/Fabric/RNCSafeAreaProviderComponentView.mm
@@ -71,18 +71,58 @@ using namespace facebook::react;
   [self invalidateSafeAreaInsets];
 }
 
+static UIEdgeInsets RNCDeriveInsetsFromWindow(UIView *view, UIEdgeInsets current)
+{
+#if TARGET_OS_IPHONE
+  // iOS 26.4+ reattach bug: UIKit can leave a reattached view's
+  // safeAreaInsets at zero indefinitely (no propagation, no callback, no
+  // layout pass). The window's insets are always correct — derive the
+  // view's geometric share of them, exactly as UIKit propagation would.
+  // Only substitutes in the broken case: attached + all-zero + window
+  // non-zero.
+  UIWindow *window = view.window;
+  if (window == nil || !UIEdgeInsetsEqualToEdgeInsets(current, UIEdgeInsetsZero)) {
+    return current;
+  }
+  UIEdgeInsets w = window.safeAreaInsets;
+  if (UIEdgeInsetsEqualToEdgeInsets(w, UIEdgeInsetsZero)) {
+    return current;
+  }
+  CGRect fw = [view convertRect:view.bounds toView:window];
+  CGFloat winW = window.bounds.size.width;
+  CGFloat winH = window.bounds.size.height;
+  UIEdgeInsets derived;
+  derived.top = MAX(0, w.top - MAX(0, CGRectGetMinY(fw)));
+  derived.left = MAX(0, w.left - MAX(0, CGRectGetMinX(fw)));
+  derived.bottom = MAX(0, w.bottom - MAX(0, winH - CGRectGetMaxY(fw)));
+  derived.right = MAX(0, w.right - MAX(0, winW - CGRectGetMaxX(fw)));
+  return derived;
+#else
+  return current;
+#endif
+}
+
 - (void)invalidateSafeAreaInsets
 {
   if (self.superview == nil) {
     return;
   }
+#if TARGET_OS_IPHONE
+  // A detached subtree legitimately reports zero insets; caching/emitting
+  // them poisons the JS context and the sent-flag until the next
+  // threshold-exceeding change (which iOS 26.4+ may never deliver). Wait
+  // for the window; didMoveToWindow re-invalidates on attach.
+  if (self.window == nil) {
+    return;
+  }
+#endif
   // This gets called before the view size is set by react-native so
   // make sure to wait so we don't set wrong insets to JS.
   if (CGSizeEqualToSize(self.frame.size, CGSizeZero)) {
     return;
   }
 
-  UIEdgeInsets safeAreaInsets = self.safeAreaInsets;
+  UIEdgeInsets safeAreaInsets = RNCDeriveInsetsFromWindow(self, self.safeAreaInsets);
   CGRect frame = [self convertRect:self.bounds toView:RNCParentViewController(self).view];
 
   if (_initialInsetsSent &&
@@ -127,6 +167,53 @@ using namespace facebook::react;
   [super layoutSubviews];
 
   [self invalidateSafeAreaInsets];
+}
+
+- (void)didMoveToWindow
+{
+  [super didMoveToWindow];
+
+  // Safe area insets are only real once the view is in a window. A layout
+  // pass on a detached subtree (e.g. a native tab's content) can cache
+  // zero insets with _initialInsetsSent = YES; if UIKit's
+  // safeAreaInsetsDidChange lands while the early-return guards above
+  // still apply, nothing re-invalidates after attach and zero is latched
+  // until an unrelated relayout (observed on iOS 26.4+). Re-reading here
+  // is idempotent: the threshold check suppresses no-op changes.
+  if (self.window != nil) {
+    [self invalidateSafeAreaInsets];
+    // iOS 26.4+: after a subtree reattach (e.g. native tabs reparenting),
+    // UIKit can apply safe-area insets to this view WITHOUT calling
+    // safeAreaInsetsDidChange, and with no further layout pass — a stale
+    // (often zero) value then stays cached forever. Observed directly via
+    // instrumentation: reattach reads top=0, the real value lands a beat
+    // later, no callback follows. Re-check on the next runloop turns; the
+    // threshold guard makes these free when nothing changed.
+    __weak __typeof__(self) weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [weakSelf invalidateSafeAreaInsets];
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [weakSelf invalidateSafeAreaInsets];
+      });
+    });
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.15 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+      [weakSelf invalidateSafeAreaInsets];
+    });
+  }
+}
+
+- (void)updateEventEmitter:(const facebook::react::EventEmitter::Shared &)eventEmitter
+{
+  [super updateEventEmitter:eventEmitter];
+
+  // invalidateSafeAreaInsets caches values and sets _initialInsetsSent
+  // BEFORE checking _eventEmitter, so an emit attempted pre-attach is
+  // silently dropped and never retried — JS then never receives the
+  // initial insets. Replay through the freshly attached emitter.
+  if (_initialInsetsSent) {
+    _initialInsetsSent = NO;
+    [self invalidateSafeAreaInsets];
+  }
 }
 
 #pragma mark - RCTComponentViewProtocol

--- a/ios/Fabric/RNCSafeAreaViewComponentView.mm
+++ b/ios/Fabric/RNCSafeAreaViewComponentView.mm
@@ -17,6 +17,33 @@ using namespace facebook::react;
 @interface RNCSafeAreaViewComponentView () <RCTRNCSafeAreaViewViewProtocol>
 @end
 
+#if TARGET_OS_IPHONE
+// Mirror of the provider-side derivation (see
+// RNCSafeAreaProviderComponentView.mm): substitute window-derived insets
+// when an attached provider view still reads all-zero (iOS 26.4+ reattach
+// propagation bug).
+static UIEdgeInsets RNCViewDeriveInsetsFromWindow(UIView *view, UIEdgeInsets current)
+{
+  UIWindow *window = view.window;
+  if (window == nil || !UIEdgeInsetsEqualToEdgeInsets(current, UIEdgeInsetsZero)) {
+    return current;
+  }
+  UIEdgeInsets w = window.safeAreaInsets;
+  if (UIEdgeInsetsEqualToEdgeInsets(w, UIEdgeInsetsZero)) {
+    return current;
+  }
+  CGRect fw = [view convertRect:view.bounds toView:window];
+  CGFloat winW = window.bounds.size.width;
+  CGFloat winH = window.bounds.size.height;
+  UIEdgeInsets derived;
+  derived.top = MAX(0, w.top - MAX(0, CGRectGetMinY(fw)));
+  derived.left = MAX(0, w.left - MAX(0, CGRectGetMinX(fw)));
+  derived.bottom = MAX(0, w.bottom - MAX(0, winH - CGRectGetMaxY(fw)));
+  derived.right = MAX(0, w.right - MAX(0, winW - CGRectGetMaxX(fw)));
+  return derived;
+}
+#endif
+
 @implementation RNCSafeAreaViewComponentView {
   RNCSafeAreaViewShadowNode::ConcreteState::Shared _state;
   UIEdgeInsets _currentSafeAreaInsets;
@@ -72,6 +99,11 @@ using namespace facebook::react;
 
 - (void)didMoveToWindow
 {
+  [self attachToProviderView];
+}
+
+- (void)attachToProviderView
+{
   UIView *previousProviderView = _providerView;
   _providerView = [self findNearestProvider];
 
@@ -84,6 +116,37 @@ using namespace facebook::react;
                                                name:RNCSafeAreaDidChange
                                              object:_providerView];
   }
+
+  // Mirror of the provider's deferred re-check (see
+  // RNCSafeAreaProviderComponentView didMoveToWindow): on iOS 26.4+ a
+  // reattached subtree can receive its safe-area insets without any
+  // callback or layout pass following, so the value read at attach time
+  // (often zero) would stick. Re-read after the runloop settles.
+  if (self.window != nil) {
+    __weak __typeof__(self) weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [weakSelf updateStateIfNecessary];
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [weakSelf updateStateIfNecessary];
+      });
+    });
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.15 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+      [weakSelf updateStateIfNecessary];
+    });
+  }
+}
+
+// findNearestProvider can race view reparenting (e.g. native tabs on
+// iOS 26.4+): at didMoveToWindow time the provider may not be in the
+// ancestor chain yet, so the fallback binds to `self` — a view that never
+// posts RNCSafeAreaDidChange — and this view reads its own (possibly zero)
+// insets until the NEXT detach/reattach re-resolves it (which is why a
+// push/pop "healed" it). Keep retrying on later passes until a real
+// provider is found; apps genuinely without a provider still converge to
+// the legacy self-fallback because retries keep returning self.
+- (BOOL)needsProviderReattach
+{
+  return _providerView == nil || _providerView == (UIView *)self;
 }
 
 - (void)safeAreaProviderInsetsDidChange:(NSNotification *)notification
@@ -103,7 +166,7 @@ using namespace facebook::react;
     return;
   }
 #if TARGET_OS_IPHONE
-  UIEdgeInsets safeAreaInsets = _providerView.safeAreaInsets;
+  UIEdgeInsets safeAreaInsets = RNCViewDeriveInsetsFromWindow(_providerView, _providerView.safeAreaInsets);
 
   if (UIEdgeInsetsEqualToEdgeInsetsWithThreshold(safeAreaInsets, _currentSafeAreaInsets, 1.0 / RCTScreenScale())) {
     return;
@@ -160,7 +223,19 @@ using namespace facebook::react;
 - (void)finalizeUpdates:(RNComponentViewUpdateMask)updateMask
 {
   [super finalizeUpdates:updateMask];
-  [self updateStateIfNecessary];
+  if ([self needsProviderReattach]) {
+    [self attachToProviderView];
+  } else {
+    [self updateStateIfNecessary];
+  }
+}
+
+- (void)layoutSubviews
+{
+  [super layoutSubviews];
+  if ([self needsProviderReattach]) {
+    [self attachToProviderView];
+  }
 }
 
 - (void)prepareForRecycle


### PR DESCRIPTION
## Summary

On iOS 26.4+ (reproduced on 26.5 and 26.6), UIKit can apply `safeAreaInsets` to a **reattached subtree without calling `safeAreaInsetsDidChange` and without a subsequent layout pass**. `RNCSafeAreaProviderComponentView` trusts that callback: a layout pass on the detached subtree caches zero insets with `_initialInsetsSent = YES`, and after reattach nothing ever re-reads — every consumer under that provider renders with zero insets (content under the status bar) until an unrelated relayout (e.g. a stack push/pop) heals it.

Any app whose navigation reparents mounted subtrees hits this — we found it via expo-router's `NativeTabs` (UITabBarController reparenting) as an intermittent ~1-in-8 cold-launch bug in a production app. iOS ≤ 26.2 is unaffected (the callback still fires there).

**Captured failure sequence** — NSLog instrumentation at every decision point in both Fabric components, Release build, iOS 26.5 simulator (`P` = provider component view, `V` = SafeAreaView component view; the real top inset is 62):

```
V attach found=self win=0            # detached during tab reparenting; findNearestProvider falls back to self
P invalidate EMIT top=0.0 win=0      # provider (superview ≠ nil, frame set, window == nil) caches+emits ZERO
V attach found=P win=1               # reattached; view re-finds the real provider
V update SKIP same top=0.0           # reads provider's UIKit insets: still 0 (not yet applied)
P didMoveToWindow top=0.0
P invalidate SKIP unchanged top=0.0  # cached 0 == current 0 → suppressed
P invalidate SKIP unchanged top=0.0  # re-checks up to +150ms: UIKit STILL reports 0
...silence...                        # UIKit then applies top=62 — no safeAreaInsetsDidChange, no layout pass, ever
```

The zero is latched: the provider's cache says "sent", the view's threshold check says "unchanged", and the OS never delivers another trigger.

**The fix (Fabric components only):**

1. **`RNCSafeAreaProviderComponentView`: don't cache/emit while `window == nil`** — a detached subtree's insets are meaningless; emitting them poisons the JS context and the sent-flag. Mirrors the `RNCSafeAreaViewComponentView` guard from #735. `didMoveToWindow` re-invalidates on attach, plus deferred re-checks after the runloop settles (idempotent through the existing threshold check).
2. **Window-geometry derivation (both components):** when an *attached* view reads all-zero `safeAreaInsets` while `window.safeAreaInsets` is non-zero, derive the view's insets geometrically from the window — the same computation UIKit propagation performs. Substituted **only** in that precisely-broken state, so legitimate zero-inset cases (status bar hidden, landscape, views positioned outside the unsafe area) are untouched.
3. **Replay the initial event when the Fabric event emitter attaches** — `invalidateSafeAreaInsets` previously set `_initialInsetsSent = YES` *before* checking `_eventEmitter`, so an emit attempted pre-attach was silently dropped and never retried; JS then never received the initial insets.
4. **`RNCSafeAreaViewComponentView`: retry `findNearestProvider` when it fell back to `self`** — during reparenting the provider may not be in the ancestor chain yet at `didMoveToWindow` time; the view then binds its `RNCSafeAreaDidChange` observer to a view that never posts. Apps genuinely without a provider still converge to the legacy self-fallback.

The Paper (old-architecture) components share the same callback assumption and likely deserve equivalent treatment; this PR only changes the Fabric files, where we could reproduce and validate. Happy to follow up if useful.

## Test Plan

**`yarn test` on this branch — passes** (prettier check, clang-format check, spotless check, `tsc --noEmit`, jest):

```
Test Suites: 3 passed, 3 total
Tests:       13 passed, 13 total
Snapshots:   11 passed, 11 total
```

**Statistical cold-launch harness** (the bug is an intermittent race, so we validated statistically): Release build of a production app using expo-router NativeTabs on an iOS 26.5 simulator; each run = terminate → cold launch → screenshot → pixel-classifier (content-under-status-bar detection):

| Build | Result |
| --- | --- |
| Unpatched (three separate builds) | 4 occurrences / 40 launches |
| Patched, with NSLog instrumentation | 0 / 40 |
| Patched, instrumentation stripped | 0 / 60 |
| Patched, fresh pod artifacts | 0 / 20 |
| iOS 26.2, patched (regression check) | clean — and 26.2 never reproduced unpatched |

**Field verification:** the original report came from a physical iPhone 16 Pro on iOS 26.6 (intermittent cold-launch overlap, self-healing on any push/pop); the patched build launches clean there.

**Note on the example app:** the bundled example doesn't exercise a subtree-reparenting navigator (the trigger), so it can't reproduce the bug — hence the harness above. Happy to run any additional verification the maintainers would like, and to share the full instrumentation logs.
