### PR TITLE
fix: register src/paper/java as a Java source set on old architecture

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -102,7 +102,8 @@ android {
             java.directories.add("${project.buildDir}/generated/source/codegen/java") // contains only java files
             kotlin.directories.add("src/fabric/java") // contains only kotlin files
         } else {
-            kotlin.directories.add("src/paper/java") // contains both java and kotlin files
+            java.directories.add("src/paper/java") // contains both java and kotlin files
+            kotlin.directories.add("src/paper/java")
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #754 — 5.9.0 crashes on launch on the old architecture:

```
java.lang.NoClassDefFoundError: Failed resolution of: Lcom/th3rdwave/safeareacontext/SafeAreaContextModule;
```

`android/src/paper/java` holds five `.java` files — `NativeSafeAreaContextSpec.java` plus the four `RNCSafeArea*Manager{Delegate,Interface}.java` — alongside two `.kt` files. The AGP 9 DSL migration in 42c50a6 (#733) registered that directory only under `kotlin.directories`. On some AGP/Kotlin combinations the Kotlin compiler reads those `.java` files for resolution but never emits class files for them, and javac never sees the directory, so they're silently dropped from the AAR. `SafeAreaContextModule` then can't resolve its superclass at runtime.

This adds the directory to `java.directories` as well, mirroring what the new-arch branch directly above already does. It's explicit either way, so it's correct regardless of which compiler picks the files up.

**On reproducibility:** I could not reproduce the drop with the example's toolchain (AGP 8.12.0, Kotlin 2.1.20, Gradle 9.3.1) — a clean old-arch build there produces all five classes. But it reproduces in a minimal AGP 8.12 + `kotlin-android` library (below), and the reporter has `dexdump` evidence of the classes being absent from every dex in a production AAB built with AGP 8.11.0 / RN 0.81.5 / Gradle 8.14.3. I haven't pinned down exactly which part of the toolchain flips the behavior, so I'd treat the exact trigger as unconfirmed — but the source set registration is wrong as written either way.

Worth noting `android.yml` does build the example with `-PnewArchEnabled=false`, but a missing class still compiles clean and nothing launches the app, so CI can't catch this class of regression today.

## Test Plan

Minimal AGP 8.12.0 + `kotlin-android` library reproducing the config — a `.java` and a `.kt` in a paper-style dir, plus a Kotlin class in `src/main` extending the Java one:

Before (`kotlin.directories` only) — **build succeeds, no warning**:
```
demo/Consumer.class
demo/PaperKotlin.class      ← PaperJavaSpec.class missing
```

After:
```
demo/Consumer.class
demo/PaperKotlin.class
demo/PaperJavaSpec.class
```

Also verified the fix on the AGP 9.2.1 built-in-Kotlin path (where the current config instead fails loudly at compile time with `Unresolved reference 'PaperJavaSpec'`), and that a clean old-arch build of the example still produces a complete AAR:

```
$ ./gradlew :react-native-safe-area-context:assembleDebug -PnewArchEnabled=false
$ unzip -l classes.jar | grep -E "NativeSafeAreaContextSpec|Manager(Delegate|Interface)"
com/facebook/react/viewmanagers/RNCSafeAreaProviderManagerDelegate.class
com/facebook/react/viewmanagers/RNCSafeAreaProviderManagerInterface.class
com/facebook/react/viewmanagers/RNCSafeAreaViewManagerDelegate.class
com/facebook/react/viewmanagers/RNCSafeAreaViewManagerInterface.class
com/th3rdwave/safeareacontext/NativeSafeAreaContextSpec.class
```
