### PR TITLE
fix(ios): remove safe area release warnings

### DIFF
--- a/common/cpp/react/renderer/components/safeareacontext/RNCSafeAreaViewState.cpp
+++ b/common/cpp/react/renderer/components/safeareacontext/RNCSafeAreaViewState.cpp
@@ -3,6 +3,8 @@
 namespace facebook {
 namespace react {
 
+RNCSafeAreaViewState::RNCSafeAreaViewState() = default;
+
 #ifdef ANDROID
 
 folly::dynamic RNCSafeAreaViewState::getDynamic() const {

--- a/common/cpp/react/renderer/components/safeareacontext/RNCSafeAreaViewState.h
+++ b/common/cpp/react/renderer/components/safeareacontext/RNCSafeAreaViewState.h
@@ -32,7 +32,7 @@ class JSI_EXPORT RNCSafeAreaViewState final {
  public:
   using Shared = std::shared_ptr<const RNCSafeAreaViewState>;
 
-  RNCSafeAreaViewState(){};
+  RNCSafeAreaViewState();
 
 #ifdef ANDROID
   RNCSafeAreaViewState(

--- a/ios/Fabric/RNCSafeAreaProviderComponentView.mm
+++ b/ios/Fabric/RNCSafeAreaProviderComponentView.mm
@@ -106,9 +106,9 @@ using namespace facebook::react;
         .insets =
             {
                 .top = safeAreaInsets.top,
-                .left = safeAreaInsets.left,
-                .bottom = safeAreaInsets.bottom,
                 .right = safeAreaInsets.right,
+                .bottom = safeAreaInsets.bottom,
+                .left = safeAreaInsets.left,
             },
         .frame =
             {


### PR DESCRIPTION
## Summary

Fixes #739.

- initialize the generated inset event in its C++ declaration order (`top`, `right`, `bottom`, `left`), removing the two `-Wreorder-init-list` diagnostics emitted per simulator architecture
- move `RNCSafeAreaViewState`'s default constructor out of the header, so `RNCSafeAreaViewState.cpp` always emits a real external symbol when the Android-only implementation is compiled out on Apple platforms

This keeps the constructor behavior unchanged and avoids adding a dummy symbol solely to satisfy libtool.

## Test Plan

- Baseline Fabric Release build on Xcode 26.5 reproduced both reorder warnings and `libtool: warning: 'RNCSafeAreaViewState.o' has no symbols`.
- Repeated the same build after the patch:

  ```sh
  xcodebuild -quiet \
    -scheme ReactTestApp \
    -workspace RNSACExample.xcworkspace \
    -destination 'generic/platform=iOS Simulator' \
    ONLY_ACTIVE_ARCH=NO \
    -configuration Release \
    CODE_SIGNING_ALLOWED=NO
  ```

  The build succeeds without either safe-area-context warning. Remaining warnings are from React Native/generated third-party pods.

- `nm -gU` on both arm64 and x86_64 Release objects reports the external `RNCSafeAreaViewState` constructor symbols.
- `./.github/scripts/build-android.sh true` — Fabric debug build succeeds for arm64-v8a, armeabi-v7a, x86, and x86_64.
- `./.github/scripts/build-android.sh false` — succeeds; React Native 0.85 reports that New Architecture can no longer be disabled.
- `yarn format:prettier:check`
- `yarn format:clang:check`
- `yarn validate:eslint` — zero errors; three existing deep-import warnings
- `yarn validate:typescript`
- `yarn validate:jest` — 21/21 tests, 11/11 snapshots
- `yarn prepare` — CommonJS, ESM, and TypeScript declaration builds

`yarn test` was also attempted, but its unchanged Android `spotlessCheck` subtask stalled at `spotlessGroovyGradle` for over five minutes on local Gradle 9.4.1. All other test-script subcommands above were run independently; no Android/Gradle source is changed in this PR.
