### PR TITLE
fix(ios): allow transparent safe area views

### DIFF
--- a/ios/Fabric/RNCSafeAreaViewComponentView.mm
+++ b/ios/Fabric/RNCSafeAreaViewComponentView.mm
@@ -32,6 +32,7 @@ using namespace facebook::react;
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
+    self.opaque = NO;
     static const auto defaultProps = std::make_shared<const RNCSafeAreaViewProps>();
     _props = defaultProps;
   }

--- a/ios/RNCSafeAreaView.m
+++ b/ios/RNCSafeAreaView.m
@@ -24,6 +24,7 @@
 - (instancetype)initWithBridge:(RCTBridge *)bridge
 {
   if (self = [super initWithFrame:CGRectZero]) {
+    self.opaque = NO;
     _bridge = bridge;
     // Defaults
     _mode = RNCSafeAreaViewModePadding;


### PR DESCRIPTION
Fixes #197

## Summary

- mark the legacy iOS SafeAreaView as non-opaque during initialization
- apply the same invariant to the Fabric component view
- keep layout, background-color handling, and the public JavaScript API unchanged

UIView defaults to opaque. Apple documents that a fully or partially transparent view must set opaque to false; otherwise rendering is unpredictable. SafeAreaView accepts transparent backgrounds, so both native implementations now opt into normal compositing.

Apple reference: https://developer.apple.com/documentation/uikit/uiview/isopaque

## Test Plan

- RED on current main: instrumented the example app on an iPhone 17 Pro simulator (iOS 26.5, Xcode 26.6, React Native 0.85.3); Fabric SafeAreaView initialized with opaque=YES
- GREEN after the change: the same runtime probe reported opaque=NO, and the red/blue background remained visible through the top safe-area inset
- yarn format:clang:check
- yarn validate:typescript
- yarn validate:eslint (0 errors; 3 pre-existing React Native deep-import warnings)
- yarn validate:jest --runInBand (4 suites, 21 tests, 11 snapshots)
- xcodebuild -workspace example/ios/RNSACExample.xcworkspace -scheme safe-area-example -configuration Debug -destination platform=iOS Simulator,id=D463F2F5-3B09-4E46-8919-C69E61AB557E CODE_SIGNING_ALLOWED=NO build