### PR TITLE
fix(web): handle empty styles without invalidating the style memo

### DIFF
--- a/src/SafeAreaView.web.tsx
+++ b/src/SafeAreaView.web.tsx
@@ -35,7 +35,7 @@ function getEdgeValue(
 export const SafeAreaView = React.forwardRef<
   NativeSafeAreaViewInstance,
   NativeSafeAreaViewProps
->(({ style = {}, mode, edges, ...rest }, ref) => {
+>(({ style, mode, edges, ...rest }, ref) => {
   const insets = useSafeAreaInsets();
 
   const edgesRecord = React.useMemo(() => {
@@ -53,7 +53,7 @@ export const SafeAreaView = React.forwardRef<
   }, [edges]);
 
   const appliedStyle = React.useMemo(() => {
-    const flatStyle = StyleSheet.flatten(style) as Record<string, number>;
+    const flatStyle = (StyleSheet.flatten(style) ?? {}) as Record<string, number>;
 
     if (mode === 'margin') {
       const {

--- a/src/SafeAreaView.web.tsx
+++ b/src/SafeAreaView.web.tsx
@@ -53,7 +53,10 @@ export const SafeAreaView = React.forwardRef<
   }, [edges]);
 
   const appliedStyle = React.useMemo(() => {
-    const flatStyle = (StyleSheet.flatten(style) ?? {}) as Record<string, number>;
+    const flatStyle = (StyleSheet.flatten(style) ?? {}) as Record<
+      string,
+      number
+    >;
 
     if (mode === 'margin') {
       const {


### PR DESCRIPTION
## Summary

Fix web SafeAreaView crashes for valid `style={null}` and `style={false}` values. Flatten to an empty object only inside the memo, and remove the per-render `{}` default that defeats memo reuse when style is omitted.

No API or native behavior changes. Existing numeric padding/margin and edge modes are preserved; null/false styles now behave like an omitted style.

## Test Plan

- React Native 0.87.1 consumer: immutable install and lint, all 13 web production targets, all four browser-extension builds, and all four production-mode Metro bundles pass. 172 installed source/native/artifact files match the verified fork. Native implementation is unchanged; both products' Android/iOS Debug builds passed immediately before this JS-only batch.

- Existing Jest suite: 21 tests / four suites / 11 snapshots pass, before and after.
- TypeScript, ESLint (three existing deep-import warnings), targeted Prettier, CJS/ESM/declaration builds and whitespace checks pass.
- Inline actual-component React/DOM checks: 14 style cases across padding and margin improve from four failures to zero. Ten rerenders without a style prop perform ten style calculations on baseline and one after the fix.
- React Doctor changed scope improves from 83 to 86 after removing the default-object allocation. The remaining fallback-provider effect warning is the intentional window-measurement notification contract, not suppressed.
- No test/spec files changed; no claim of physical-device/visual end-to-end coverage.
