### PR TITLE
fix(web): forward provider view props and listen for standard transitions

### DIFF
--- a/src/CompatNativeSafeAreaProvider.tsx
+++ b/src/CompatNativeSafeAreaProvider.tsx
@@ -25,5 +25,9 @@ export function CompatNativeSafeAreaProvider({
     // @ts-ignore: missing properties
     onInsetsChange({ nativeEvent: { insets, frame } });
   }, [onInsetsChange, window.height, window.width]);
-  return <View {...rest} style={style}>{children}</View>;
+  return (
+    <View {...rest} style={style}>
+      {children}
+    </View>
+  );
 }

--- a/src/CompatNativeSafeAreaProvider.tsx
+++ b/src/CompatNativeSafeAreaProvider.tsx
@@ -6,6 +6,7 @@ export function CompatNativeSafeAreaProvider({
   children,
   style,
   onInsetsChange,
+  ...rest
 }: NativeSafeAreaProviderProps) {
   const window = useWindowDimensions();
   React.useEffect(() => {
@@ -24,5 +25,5 @@ export function CompatNativeSafeAreaProvider({
     // @ts-ignore: missing properties
     onInsetsChange({ nativeEvent: { insets, frame } });
   }, [onInsetsChange, window.height, window.width]);
-  return <View style={style}>{children}</View>;
+  return <View {...rest} style={style}>{children}</View>;
 }

--- a/src/NativeSafeAreaProvider.web.tsx
+++ b/src/NativeSafeAreaProvider.web.tsx
@@ -5,8 +5,8 @@ import { View } from 'react-native';
 import type { NativeSafeAreaProviderProps } from './SafeArea.types';
 
 const CSSTransitions: Record<string, string> = {
+  transition: 'transitionend',
   WebkitTransition: 'webkitTransitionEnd',
-  Transition: 'transitionEnd',
   MozTransition: 'transitionend',
   MSTransition: 'msTransitionEnd',
   OTransition: 'oTransitionEnd',
@@ -16,6 +16,7 @@ export function NativeSafeAreaProvider({
   children,
   style,
   onInsetsChange,
+  ...rest
 }: NativeSafeAreaProviderProps) {
   const viewRef = React.useRef<View>(null);
 
@@ -108,7 +109,7 @@ export function NativeSafeAreaProvider({
   }, [onInsetsChange]);
 
   return (
-    <View ref={viewRef} style={style}>
+    <View {...rest} ref={viewRef} style={style}>
       {children}
     </View>
   );
@@ -121,7 +122,7 @@ function getSupportedTransitionEvent(): string {
   }
   const element = document.createElement('invalidtype');
 
-  _supportedTransitionEvent = CSSTransitions.Transition;
+  _supportedTransitionEvent = CSSTransitions.transition;
   for (const key in CSSTransitions) {
     if (element.style[key as keyof CSSStyleDeclaration] !== undefined) {
       _supportedTransitionEvent = CSSTransitions[key];


### PR DESCRIPTION
## Summary

- Forward View props through both web and compatibility SafeAreaProvider implementations. Props such as testID and onLayout are declared but currently dropped.
- Detect the standard `transition` property and use the correct `transitionend` event, before legacy prefixes. The existing `Transition`/`transitionEnd` pair never identifies standard CSS transitions, leaving env() inset changes unreported in standard-only environments.

No API or native implementation changes. Previously dropped View props now reach the backing View; standard inset transitions now trigger the existing measurement callback. Existing cleanup and prefixed fallbacks are retained.

## Test Plan

- React Native 0.87.1 consumer: immutable install and lint, all 13 web production targets, all four browser-extension builds, and all four production-mode Metro bundles pass. 172 installed source/native/artifact files match the verified fork. Native implementation is unchanged; both products' Android/iOS Debug builds passed immediately before this JS-only batch.

- Existing Jest suite: 21 tests / four suites / 11 snapshots pass.
- TypeScript, ESLint (three existing deep-import warnings), targeted Prettier, CJS/ESM/declaration builds and whitespace checks pass.
- Actual source components with React 19/JSDOM: both providers forward testID/onLayout; a standard transition event updates insets exactly once; unmount removes the measurement element and resize listener. Baseline drops both providers' props and produces zero updates for that event.
- React Doctor: 86/100, only the existing compatibility-provider measurement-through-effect warning. No rule suppression.
- No test/spec files changed. Event/measurement checks use DOM mocks, not a real mobile browser/device notch.
